### PR TITLE
Support #flatten

### DIFF
--- a/lib/graphiti_spec_helpers/node.rb
+++ b/lib/graphiti_spec_helpers/node.rb
@@ -44,6 +44,10 @@ module GraphitiSpecHelpers
       end
     end
 
+    def respond_to?(*args)
+      super
+    end
+
     def link(relationship_name, name)
       if @relationships.has_key?(relationship_name)
         links = @relationships[relationship_name][:links]

--- a/lib/graphiti_spec_helpers/version.rb
+++ b/lib/graphiti_spec_helpers/version.rb
@@ -1,3 +1,3 @@
 module GraphitiSpecHelpers
-  VERSION = "1.0.beta.4"
+  VERSION = "1.0.beta.5"
 end

--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -70,6 +70,12 @@ describe GraphitiSpecHelpers do
     end
   end
 
+  describe '#flatten' do
+    it 'works' do
+      expect(jsonapi_data.flatten.map(&:id)).to eq([100])
+    end
+  end
+
   describe '#sideloads/sideload' do
     context 'when relation is an array' do
       it 'returns relevant node' do


### PR DESCRIPTION
Amazingly, we need to override `respond_to?` and call `super`. Seems to
be a bug: https://bugs.ruby-lang.org/issues/11465