### PR TITLE
Allow headers to be passed in http methods and bump ruby version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: ruby
 rvm:
-  - 2.2.3
+  - 2.6.3
 before_install: gem install bundler -v 1.11.2

--- a/lib/graphiti_spec_helpers/helpers.rb
+++ b/lib/graphiti_spec_helpers/helpers.rb
@@ -49,24 +49,24 @@ module GraphitiSpecHelpers
       }
     end
 
-    def jsonapi_get(url, params: {})
-      get url, params: params, headers: jsonapi_headers
+    def jsonapi_get(url, params: {}, headers: {})
+      get url, params: params, headers: jsonapi_headers.merge(headers)
     end
 
-    def jsonapi_post(url, payload)
-      post url, params: payload.to_json, headers: jsonapi_headers
+    def jsonapi_post(url, payload, headers: {})
+      post url, params: payload.to_json, headers: jsonapi_headers.merge(headers)
     end
 
-    def jsonapi_put(url, payload)
-      put url, params: payload.to_json, headers: jsonapi_headers
+    def jsonapi_put(url, payload, headers: {})
+      put url, params: payload.to_json, headers: jsonapi_headers.merge(headers)
     end
 
-    def jsonapi_patch(url, payload)
-      patch url, params: payload.to_json, headers: jsonapi_headers
+    def jsonapi_patch(url, payload, headers: {})
+      patch url, params: payload.to_json, headers: jsonapi_headers.merge(headers)
     end
 
-    def jsonapi_delete(url)
-      delete url, headers: jsonapi_headers
+    def jsonapi_delete(url, headers)
+      delete url, headers: jsonapi_headers.merge(headers)
     end
 
     def json_datetime(value)


### PR DESCRIPTION
Allow headers to be supplied to `jsonapi_VERB` methods and to be merged with `jsonapi_headers`. 

Bump Ruby version from `2.2.3` to `2.6.3`