### PR TITLE
Allow for string ids (like a UUID)

### DIFF
--- a/lib/graphiti_spec_helpers/node.rb
+++ b/lib/graphiti_spec_helpers/node.rb
@@ -9,7 +9,11 @@ module GraphitiSpecHelpers
     end
 
     def id
-      rawid.to_i
+      begin
+        Integer(rawid) # Only convert if using integer ids
+      rescue ArgumentError
+        rawid
+      end
     end
 
     def rawid


### PR DESCRIPTION
I am using UUIDs for my primary keys in a postgres rails app, so this allows for string based IDs in tests, but still coerces integer IDs as before