### PR TITLE
require rspec-core as a dependency of the matchers

### DIFF
--- a/lib/graphiti_spec_helpers/rspec.rb
+++ b/lib/graphiti_spec_helpers/rspec.rb
@@ -1,3 +1,4 @@
+require 'rspec/core'
 require 'graphiti_spec_helpers'
 
 ::RSpec.shared_context 'resource testing', type: :resource do |parameter|


### PR DESCRIPTION
The rspec matchers depend on rspec-core already being loaded (or being autoloaded).

However, apps that leverage Bundlers `require:` option for specifying the entrypoint file to be loaded by Bundle.require will not necessarily have autoloading configured at that point (if ever). This ensures that should the rspec.rb file be loaded prior to rspec, it will properly require rspec/core so that the RSpec references actually work.

And the end result is that users don't need to explicitly `require 'graphiti_spec_helpers'` in a spec-helper at all, but may instead simply adjust their Gemfile:
```rb
group :test do
    gem "graphiti_spec_helpers", require: "graphiti_spec_helpers/rspec"
end
```

fixes #18