### PR TITLE
jsonapi_included helper may accept symbol keys

### DIFF
--- a/lib/graphiti_spec_helpers/helpers.rb
+++ b/lib/graphiti_spec_helpers/helpers.rb
@@ -27,7 +27,7 @@ module GraphitiSpecHelpers
 
       nodes =  _jsonapi_included.map { |i| node(from: i) }
       if type
-        nodes.select! { |n| n.jsonapi_type == type }
+        nodes.select! { |n| n.jsonapi_type == type.to_s }
       end
       instance_variable_set(variable, nodes)
       nodes


### PR DESCRIPTION
the `included` helper has a subtle "bug" behavior.

`included("users")` followed by `included(:users)` _already_ works, because the memoization variable accepts both strings and symbol values. However, invoking the symbol form first will erronously memoize an empty array because the type filtering does not account for symbols.

At the very least, symbol and string usage should be consistent. We could prevent symbol usage entirely by refusing to memoize the symbol-keyed results. However, I think a more friendly resolution is to just allow symbol type comparison to match successfully.