### PR TITLE
Allow passing AR records to jsonapi_* http operations

### DIFF
--- a/lib/graphiti_spec_helpers/helpers.rb
+++ b/lib/graphiti_spec_helpers/helpers.rb
@@ -50,23 +50,23 @@ module GraphitiSpecHelpers
     end
 
     def jsonapi_get(url, params: {}, headers: {})
-      get url, params: params, headers: jsonapi_headers.merge(headers)
+      get url_for(url), params: params, headers: jsonapi_headers.merge(headers)
     end
 
     def jsonapi_post(url, payload, headers: {})
-      post url, params: payload.to_json, headers: jsonapi_headers.merge(headers)
+      post url_for(url), params: payload.to_json, headers: jsonapi_headers.merge(headers)
     end
 
     def jsonapi_put(url, payload, headers: {})
-      put url, params: payload.to_json, headers: jsonapi_headers.merge(headers)
+      put url_for(url), params: payload.to_json, headers: jsonapi_headers.merge(headers)
     end
 
     def jsonapi_patch(url, payload, headers: {})
-      patch url, params: payload.to_json, headers: jsonapi_headers.merge(headers)
+      patch url_for(url), params: payload.to_json, headers: jsonapi_headers.merge(headers)
     end
 
     def jsonapi_delete(url, headers: {})
-      delete url, headers: jsonapi_headers.merge(headers)
+      delete url_for(url), headers: jsonapi_headers.merge(headers)
     end
 
     def json_datetime(value)


### PR DESCRIPTION
Rationale: the `jsonapi_*` helpers for GET/POST/PUT/PATCH/DELETE each accept a url. In many api specs, the url can be derived from the ActiveRecord record(s) that are created before-hand. This allows the specs to pass the AR records to the jsonapi_* helpers directly and have the URL derived from the model the same way that Rails derives its routing for a given AR model instance.

that allows make_request subjects like:
 `jsonapi_get order`, `jsonapi_put user`, `jsonapi_delete card`  and for index: `jsonapi_get products_path`


Initial slack discussion: https://graphiti-api.slack.com/archives/C5A4UEMGS/p1658959255745979

The url_for helper still accepts a regular string, so it should be backwards compatible with existing usage.