### PR TITLE
Support matching against RSpec's`include` builtin

### DIFF
--- a/lib/graphiti_spec_helpers/node.rb
+++ b/lib/graphiti_spec_helpers/node.rb
@@ -39,6 +39,7 @@ module GraphitiSpecHelpers
     def attributes
       @attributes
     end
+    alias :to_hash :attributes
 
     def method_missing(id, *args, &blk)
       if @attributes.has_key?(id)

--- a/lib/graphiti_spec_helpers/rspec.rb
+++ b/lib/graphiti_spec_helpers/rspec.rb
@@ -54,7 +54,7 @@ require 'graphiti_spec_helpers'
   end
 end
 
-RSpec.shared_context 'remote api' do
+::RSpec.shared_context 'remote api' do
   # Fake request headers
   around do |e|
     ctx = OpenStruct.new \


### PR DESCRIPTION
RSpec's builtin `include` matcher matches against elements that are
Hashes or respond to to_hash (or include?)

In order to be able to use the include matcher against Node instances,
Node must respond to to_hash or include?. Better still, since Node's
internal @attributes are already a HashWithIndifferentAccess, we can
just return the attributes for matching. (Which means we can match using
string or symbol keys indifferently)
