### PR TITLE
alias Node#key? to Node#has_key?

### DIFF
--- a/lib/graphiti_spec_helpers/node.rb
+++ b/lib/graphiti_spec_helpers/node.rb
@@ -27,6 +27,7 @@ module GraphitiSpecHelpers
     def has_key?(key)
       @attributes.has_key?(key)
     end
+    alias :key? :has_key?
 
     def [](key)
       @attributes[key] || @attributes[key.to_s]


### PR DESCRIPTION
Test helpers (like rspec's hash_including) like to check for key? when doing fuzzy hash-like assertions. This alias ensures Node instances are treated like hashes for these fuzzy comparisons.

In particular, this adds support for rspec-mocks `hash_including` matcher: https://github.com/rspec/rspec-mocks/blob/868bf98d2aae5f0db15441a41b86b5f9346a12dd/lib/rspec/mocks/argument_matchers.rb#L195